### PR TITLE
Add passthrough window sample

### DIFF
--- a/Samples/XrSamples/XrPassthroughWindow/CMakeLists.txt
+++ b/Samples/XrSamples/XrPassthroughWindow/CMakeLists.txt
@@ -1,0 +1,40 @@
+project(xrpassthroughwindow)
+
+if(NOT TARGET OpenXR::openxr_loader)
+    find_package(OpenXR REQUIRED)
+endif()
+
+file(GLOB_RECURSE SRC_FILES
+    Src/*.c
+    Src/*.cpp
+)
+
+if(ANDROID)
+    add_library(${PROJECT_NAME} MODULE ${SRC_FILES})
+    target_include_directories(${PROJECT_NAME} PUBLIC ${ANDROID_NDK}/sources/android/native_app_glue)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        android
+        EGL
+        GLESv3
+        log
+        ktx
+    )
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-u ANativeActivity_onCreate")
+elseif(WIN32)
+    add_definitions(-D_USE_MATH_DEFINES)
+    add_executable(${PROJECT_NAME} ${SRC_FILES})
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E copy_directory
+        "${CMAKE_CURRENT_LIST_DIR}/assets"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/assets"
+        VERBATIM)
+
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E copy_directory
+        "${CMAKE_SOURCE_DIR}/SampleXrFramework/res/raw"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/font/res/raw"
+        VERBATIM)
+endif()
+
+target_include_directories(${PROJECT_NAME} PRIVATE Src)
+target_link_libraries(${PROJECT_NAME} PRIVATE samplexrframework)

--- a/Samples/XrSamples/XrPassthroughWindow/Projects/Android/AndroidManifest.xml
+++ b/Samples/XrSamples/XrPassthroughWindow/Projects/Android/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.oculus.sdk.xrpassthroughwindow"
+    android:versionCode="1"
+    android:versionName="1.0"
+    android:installLocation="auto">
+  <uses-feature android:glEsVersion="0x00030001" android:required="true" />
+  <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" />
+  <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+  <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
+  <application android:allowBackup="false" android:label="@string/app_name">
+    <meta-data android:name="com.oculus.supportedDevices" android:value="all" />
+    <activity
+        android:name="com.oculus.sdk.xrpassthroughwindow.MainActivity"
+        android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
+        android:label="@string/app_name"
+        android:launchMode="singleTask"
+        android:screenOrientation="landscape"
+        android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode"
+        android:exported="true">
+      <meta-data android:name="android.app.lib_name" android:value="xrpassthroughwindow" />
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/Samples/XrSamples/XrPassthroughWindow/Projects/Android/build.gradle
+++ b/Samples/XrSamples/XrPassthroughWindow/Projects/Android/build.gradle
@@ -1,0 +1,75 @@
+/*
+ * Build file for XrPassthroughWindow sample
+ */
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:7.0.3"
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+apply plugin: 'com.android.application'
+
+android {
+  compileSdk 32
+
+  defaultConfig {
+    applicationId "com.oculus.sdk.xrpassthroughwindow"
+    minSdk 26
+    targetSdk 32
+    versionCode 1
+    versionName "1.0"
+    externalNativeBuild {
+      ndk {
+        abiFilters 'arm64-v8a'
+      }
+      ndkBuild {
+        abiFilters 'arm64-v8a'
+      }
+      cmake {
+         targets "xrpassthroughwindow"
+      }
+    }
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile 'AndroidManifest.xml'
+      java.srcDirs = ['../../java']
+      assets.srcDirs = ['../../assets']
+      res.srcDirs = ['../../res']
+    }
+  }
+
+  buildTypes {
+    debug {
+      debuggable true
+    }
+
+    release {
+      debuggable false
+    }
+  }
+
+  externalNativeBuild {
+    cmake {
+      path file('../../../../CMakeLists.txt')
+    }
+  }
+
+  buildFeatures {
+    prefab true
+  }
+}
+
+dependencies {
+  implementation 'org.khronos.openxr:openxr_loader_for_android:1.1.46'
+}

--- a/Samples/XrSamples/XrPassthroughWindow/README.md
+++ b/Samples/XrSamples/XrPassthroughWindow/README.md
@@ -1,0 +1,3 @@
+# OpenXR Passthrough Window Sample
+
+This sample demonstrates how to show passthrough as the background and render a simple floating window that can be resized and faded using the controller joysticks. The window itself is currently empty but can be populated with content later.

--- a/Samples/XrSamples/XrPassthroughWindow/Src/XrHelper.h
+++ b/Samples/XrSamples/XrPassthroughWindow/Src/XrHelper.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * Licensed under the Oculus SDK License Agreement (the "License");
+ * you may not use the Oculus SDK except in compliance with the License,
+ * which is provided at the time of installation or download, or which
+ * otherwise accompanies this software in either electronic or hard copy form.
+ *
+ * You may obtain a copy of the License at
+ * https://developer.oculus.com/licenses/oculussdk/
+ *
+ * Unless required by applicable law or agreed to in writing, the Oculus SDK
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/************************************************************************************************
+Filename    :   XrHelper.h
+Content     :   Base interface to wrap openxr extension functionality
+Created     :   September 2023
+Copyright   :   Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+************************************************************************************************/
+#pragma once
+
+#include <XrApp.h>
+
+class XrHelper {
+   public:
+    explicit XrHelper(XrInstance instance) : Instance(instance) {}
+    virtual ~XrHelper() = default;
+
+    virtual void SessionInit(XrSession session) = 0;
+    virtual void SessionEnd() = 0;
+    virtual void Update(XrSpace currentSpace, XrTime predictedDisplayTime) = 0;
+
+   protected:
+    XrInstance Instance;
+};

--- a/Samples/XrSamples/XrPassthroughWindow/Src/XrPassthroughHelper.cpp
+++ b/Samples/XrSamples/XrPassthroughWindow/Src/XrPassthroughHelper.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * Licensed under the Oculus SDK License Agreement (the "License");
+ * you may not use the Oculus SDK except in compliance with the License,
+ * which is provided at the time of installation or download, or which
+ * otherwise accompanies this software in either electronic or hard copy form.
+ *
+ * You may obtain a copy of the License at
+ * https://developer.oculus.com/licenses/oculussdk/
+ *
+ * Unless required by applicable law or agreed to in writing, the Oculus SDK
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/************************************************************************************************
+Filename    :   XrPassthroughHelper.cpp
+Content     :   Helper inteface for openxr XR_FB_spatial_entity and related extensions
+Created     :   September 2023
+Authors     :   Adam Bengis, Peter Chan
+Language    :   C++
+Copyright   :   Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+************************************************************************************************/
+
+#include "XrPassthroughHelper.h"
+
+#include <Misc/Log.h>
+
+std::vector<const char*> XrPassthroughHelper::RequiredExtensionNames() {
+    return {XR_FB_PASSTHROUGH_EXTENSION_NAME, XR_FB_TRIANGLE_MESH_EXTENSION_NAME};
+}
+
+XrPassthroughHelper::XrPassthroughHelper(XrInstance instance) : XrHelper(instance) {
+    // XR_FB_passthrough
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrCreatePassthroughFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrCreatePassthroughFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrDestroyPassthroughFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrDestroyPassthroughFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrPassthroughStartFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrPassthroughStartFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrPassthroughPauseFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrPassthroughPauseFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrCreatePassthroughLayerFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrCreatePassthroughLayerFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrDestroyPassthroughLayerFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrDestroyPassthroughLayerFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrPassthroughLayerSetStyleFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrPassthroughLayerSetStyleFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrCreateGeometryInstanceFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrCreateGeometryInstanceFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrDestroyGeometryInstanceFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrDestroyGeometryInstanceFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrGeometryInstanceSetTransformFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrGeometryInstanceSetTransformFB)));
+
+    // XR_FB_triangle_mesh
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrCreateTriangleMeshFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrCreateTriangleMeshFB)));
+    OXR(xrGetInstanceProcAddr(
+        instance,
+        "xrDestroyTriangleMeshFB",
+        reinterpret_cast<PFN_xrVoidFunction*>(&XrDestroyTriangleMeshFB)));
+}
+
+void XrPassthroughHelper::SessionInit(XrSession session) {
+    Session = session;
+
+    XrPassthroughCreateInfoFB passthroughInfo{XR_TYPE_PASSTHROUGH_CREATE_INFO_FB};
+    OXR(XrCreatePassthroughFB(Session, &passthroughInfo, &Passthrough));
+}
+
+void XrPassthroughHelper::SessionEnd() {
+    OXR(XrDestroyPassthroughFB(Passthrough));
+
+    Session = XR_NULL_HANDLE;
+}
+
+void XrPassthroughHelper::Update(XrSpace currentSpace, XrTime predictedDisplayTime) {}
+
+XrPassthroughLayerFB XrPassthroughHelper::CreateProjectedLayer() const {
+    XrPassthroughLayerFB layer = XR_NULL_HANDLE;
+
+    XrPassthroughLayerCreateInfoFB layerInfo{XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB};
+    layerInfo.passthrough = Passthrough;
+    layerInfo.purpose = XR_PASSTHROUGH_LAYER_PURPOSE_PROJECTED_FB;
+    layerInfo.flags = XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB;
+    XrResult result = XrCreatePassthroughLayerFB(Session, &layerInfo, &layer);
+    if (result != XR_SUCCESS) {
+        ALOGE("xrCreatePassthroughLayerFB failed, error %d", result);
+        return XR_NULL_HANDLE;
+    }
+
+    XrPassthroughStyleFB style{XR_TYPE_PASSTHROUGH_STYLE_FB};
+    style.textureOpacityFactor = 1.0f;
+    style.edgeColor = {0.0f, 0.0f, 0.0f, 0.0f};
+    result = XrPassthroughLayerSetStyleFB(layer, &style);
+    if (result != XR_SUCCESS) {
+        ALOGE("xrPassthroughLayerSetStyleFBfailed, error %d", result);
+        return XR_NULL_HANDLE;
+    }
+
+    return layer;
+}
+
+void XrPassthroughHelper::DestroyLayer(XrPassthroughLayerFB layer) const {
+    OXR(XrDestroyPassthroughLayerFB(layer));
+}
+
+XrGeometryInstanceFB XrPassthroughHelper::CreateGeometryInstance(
+    XrPassthroughLayerFB layer,
+    XrSpace baseSpace,
+    const std::vector<XrVector3f>& vertices,
+    const std::vector<uint32_t>& indices) {
+    Geometry geometry;
+
+    XrTriangleMeshCreateInfoFB meshInfo{XR_TYPE_TRIANGLE_MESH_CREATE_INFO_FB};
+    meshInfo.vertexCount = vertices.size();
+    meshInfo.vertexBuffer = vertices.data();
+    meshInfo.triangleCount = indices.size() / 3;
+    meshInfo.indexBuffer = indices.data();
+    meshInfo.windingOrder = XR_WINDING_ORDER_UNKNOWN_FB;
+    XrResult result = XrCreateTriangleMeshFB(Session, &meshInfo, &geometry.Mesh);
+    if (result != XR_SUCCESS) {
+        ALOGE("xrCreateTriangleMeshFB, error %d", result);
+        return XR_NULL_HANDLE;
+    }
+
+    geometry.Transform.type = XR_TYPE_GEOMETRY_INSTANCE_TRANSFORM_FB;
+    geometry.Transform.baseSpace = baseSpace;
+    geometry.Transform.pose.orientation = {0.0f, 0.0f, 0.0f, 1.0f};
+    geometry.Transform.pose.position = {0.0f, 0.0f, 0.0f};
+    geometry.Transform.scale = {1.0f, 1.0f, 1.0f};
+
+    XrGeometryInstanceCreateInfoFB geometryInfo{XR_TYPE_GEOMETRY_INSTANCE_CREATE_INFO_FB};
+    geometryInfo.layer = layer;
+    geometryInfo.mesh = geometry.Mesh;
+    geometryInfo.scale = geometry.Transform.scale;
+    geometryInfo.baseSpace = baseSpace;
+    geometryInfo.pose = geometry.Transform.pose;
+    result = XrCreateGeometryInstanceFB(Session, &geometryInfo, &geometry.Instance);
+    if (result != XR_SUCCESS) {
+        ALOGE("xrCreateGeometryInstanceFB, error %d", result);
+        OXR(XrDestroyTriangleMeshFB(geometry.Mesh));
+        return XR_NULL_HANDLE;
+    }
+
+    Geometries.emplace_back(geometry);
+    return geometry.Instance;
+}
+
+void XrPassthroughHelper::DestroyGeometryInstance(XrGeometryInstanceFB instance) {
+    auto iter = std::find_if(Geometries.begin(), Geometries.end(), [instance](const auto& geo) {
+        return geo.Instance == instance;
+    });
+    if (iter == Geometries.end()) {
+        return;
+    }
+
+    OXR(XrDestroyTriangleMeshFB(iter->Mesh));
+    OXR(XrDestroyGeometryInstanceFB(iter->Instance));
+    Geometries.erase(iter);
+}
+
+void XrPassthroughHelper::SetGeometryInstanceTransform(
+    XrGeometryInstanceFB instance,
+    XrTime time,
+    const XrPosef& pose,
+    const XrVector3f& scale) {
+    auto iter = std::find_if(Geometries.begin(), Geometries.end(), [instance](const auto& geo) {
+        return geo.Instance == instance;
+    });
+    if (iter == Geometries.end()) {
+        return;
+    }
+
+    auto& transform = iter->Transform;
+    transform.time = time;
+    transform.pose = pose;
+    transform.scale = scale;
+    OXR(XrGeometryInstanceSetTransformFB(instance, &transform));
+}
+
+void XrPassthroughHelper::Start() const {
+    OXR(XrPassthroughStartFB(Passthrough));
+}
+
+void XrPassthroughHelper::Pause() const {
+    OXR(XrPassthroughPauseFB(Passthrough));
+}

--- a/Samples/XrSamples/XrPassthroughWindow/Src/XrPassthroughHelper.h
+++ b/Samples/XrSamples/XrPassthroughWindow/Src/XrPassthroughHelper.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * Licensed under the Oculus SDK License Agreement (the "License");
+ * you may not use the Oculus SDK except in compliance with the License,
+ * which is provided at the time of installation or download, or which
+ * otherwise accompanies this software in either electronic or hard copy form.
+ *
+ * You may obtain a copy of the License at
+ * https://developer.oculus.com/licenses/oculussdk/
+ *
+ * Unless required by applicable law or agreed to in writing, the Oculus SDK
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/************************************************************************************************
+Filename    :   XrPassthroughHelper.h
+Content     :   Helper inteface for openxr XR_FB_passthrough and related extensions
+Created     :   September 2023
+Authors     :   Adam Bengis, Peter Chan
+Language    :   C++
+Copyright   :   Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+************************************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+
+#include "XrHelper.h"
+
+class XrPassthroughHelper : public XrHelper {
+   public:
+    static std::vector<const char*> RequiredExtensionNames();
+
+   public:
+    explicit XrPassthroughHelper(XrInstance instance);
+
+    void SessionInit(XrSession session) override;
+    void SessionEnd() override;
+    void Update(XrSpace currentSpace, XrTime predictedDisplayTime) override;
+
+    XrPassthroughLayerFB CreateProjectedLayer() const;
+    void DestroyLayer(XrPassthroughLayerFB layer) const;
+
+    XrGeometryInstanceFB CreateGeometryInstance(
+        XrPassthroughLayerFB layer,
+        XrSpace baseSpace,
+        const std::vector<XrVector3f>& vertices,
+        const std::vector<uint32_t>& indices);
+    void DestroyGeometryInstance(XrGeometryInstanceFB instance);
+    void SetGeometryInstanceTransform(
+        XrGeometryInstanceFB instance,
+        XrTime time,
+        const XrPosef& pose,
+        const XrVector3f& scale);
+
+    void Start() const;
+    void Pause() const;
+
+   private:
+    XrSession Session = XR_NULL_HANDLE;
+
+    // XR_FB_passthrough
+    PFN_xrCreatePassthroughFB XrCreatePassthroughFB = nullptr;
+    PFN_xrDestroyPassthroughFB XrDestroyPassthroughFB = nullptr;
+    PFN_xrPassthroughStartFB XrPassthroughStartFB = nullptr;
+    PFN_xrPassthroughPauseFB XrPassthroughPauseFB = nullptr;
+    PFN_xrCreatePassthroughLayerFB XrCreatePassthroughLayerFB = nullptr;
+    PFN_xrDestroyPassthroughLayerFB XrDestroyPassthroughLayerFB = nullptr;
+    PFN_xrPassthroughLayerSetStyleFB XrPassthroughLayerSetStyleFB = nullptr;
+    PFN_xrCreateGeometryInstanceFB XrCreateGeometryInstanceFB = nullptr;
+    PFN_xrDestroyGeometryInstanceFB XrDestroyGeometryInstanceFB = nullptr;
+    PFN_xrGeometryInstanceSetTransformFB XrGeometryInstanceSetTransformFB = nullptr;
+
+    // XR_FB_triangle_mesh
+    PFN_xrCreateTriangleMeshFB XrCreateTriangleMeshFB = nullptr;
+    PFN_xrDestroyTriangleMeshFB XrDestroyTriangleMeshFB = nullptr;
+
+    struct Geometry {
+        XrGeometryInstanceFB Instance = XR_NULL_HANDLE;
+        XrTriangleMeshFB Mesh = XR_NULL_HANDLE;
+        XrGeometryInstanceTransformFB Transform{XR_TYPE_GEOMETRY_INSTANCE_TRANSFORM_FB};
+    };
+
+    XrPassthroughFB Passthrough = XR_NULL_HANDLE;
+    std::vector<Geometry> Geometries;
+};

--- a/Samples/XrSamples/XrPassthroughWindow/Src/main.cpp
+++ b/Samples/XrSamples/XrPassthroughWindow/Src/main.cpp
@@ -1,0 +1,110 @@
+#include <OVR_Math.h>
+#include <XrApp.h>
+#include <Input/ControllerRenderer.h>
+#include <Render/GeometryRenderer.h>
+#include "XrPassthroughHelper.h"
+
+class XrPassthroughWindowApp : public OVRFW::XrApp {
+public:
+    XrPassthroughWindowApp() = default;
+
+    std::vector<const char*> GetExtensions() override {
+        std::vector<const char*> exts = XrApp::GetExtensions();
+        for (const auto& e : XrPassthroughHelper::RequiredExtensionNames()) {
+            exts.push_back(e);
+        }
+        return exts;
+    }
+
+    bool SessionInit() override {
+        passthrough_ = std::make_unique<XrPassthroughHelper>(GetInstance());
+        passthrough_->SessionInit(GetSession());
+        layer_ = passthrough_->CreateProjectedLayer();
+        passthrough_->Start();
+
+        leftController_.Init(true);
+        rightController_.Init(false);
+
+        quad_.Init(OVRFW::BuildTesselatedQuadDescriptor(4, 4, false));
+        quad_.ChannelControl = {0, 1, 0, 1};
+        return true;
+    }
+
+    void SessionEnd() override {
+        quad_.Shutdown();
+        leftController_.Shutdown();
+        rightController_.Shutdown();
+        if (passthrough_) {
+            if (window_ != XR_NULL_HANDLE) {
+                passthrough_->DestroyGeometryInstance(window_);
+            }
+            passthrough_->DestroyLayer(layer_);
+            passthrough_->SessionEnd();
+            passthrough_.reset();
+        }
+    }
+
+    void PreProjectionAddLayer(xrCompositorLayerUnion* layers, int& layerCount) override {
+        if (layer_ != XR_NULL_HANDLE) {
+            XrCompositionLayerPassthroughFB ptLayer{XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB};
+            ptLayer.layerHandle = layer_;
+            layers[layerCount++].Passthrough = ptLayer;
+        }
+    }
+
+    void Update(const OVRFW::ovrApplFrameIn& in) override {
+        XrSpace space = GetCurrentSpace();
+        XrTime time = ToXrTime(in.PredictedDisplayTime);
+        passthrough_->Update(space, time);
+
+        if (window_ == XR_NULL_HANDLE) {
+            const std::vector<XrVector3f> verts{
+                {-0.5f,-0.5f,0.0f}, {-0.5f,0.5f,0.0f}, {0.5f,0.5f,0.0f}, {0.5f,-0.5f,0.0f}};
+            const std::vector<uint32_t> idx{0,1,2,2,3,0};
+            window_ = passthrough_->CreateGeometryInstance(layer_, space, verts, idx);
+        }
+
+        scale_ += in.RightRemoteJoystick.y * 0.01f;
+        scale_ = OVR::Alg::Clamp(scale_, 0.2f, 3.0f);
+        alpha_ += in.RightRemoteJoystick.x * 0.01f;
+        alpha_ = OVR::Alg::Clamp(alpha_, 0.0f, 1.0f);
+
+        OVR::Posef pose = in.HeadPose * OVR::Posef(OVR::Quatf(), {0.0f, 0.0f, -1.5f});
+        quad_.SetPose(pose);
+        quad_.SetScale({scale_, scale_, 1.0f});
+        quad_.DiffuseColor.w = alpha_;
+        quad_.Update();
+
+        passthrough_->SetGeometryInstanceTransform(
+            window_, time, ToXrPosef(pose), {scale_, scale_, 1.0f});
+
+        if (in.LeftRemoteTracked) {
+            leftController_.Update(in.LeftRemotePose);
+        }
+        if (in.RightRemoteTracked) {
+            rightController_.Update(in.RightRemotePose);
+        }
+    }
+
+    void Render(const OVRFW::ovrApplFrameIn& in, OVRFW::ovrRendererOutput& out) override {
+        quad_.Render(out.Surfaces);
+        if (in.LeftRemoteTracked) {
+            leftController_.Render(out.Surfaces);
+        }
+        if (in.RightRemoteTracked) {
+            rightController_.Render(out.Surfaces);
+        }
+    }
+
+private:
+    std::unique_ptr<XrPassthroughHelper> passthrough_;
+    XrPassthroughLayerFB layer_ = XR_NULL_HANDLE;
+    XrGeometryInstanceFB window_ = XR_NULL_HANDLE;
+    float scale_ = 1.0f;
+    float alpha_ = 0.8f;
+    OVRFW::GeometryRenderer quad_;
+    OVRFW::ControllerRenderer leftController_;
+    OVRFW::ControllerRenderer rightController_;
+};
+
+ENTRY_POINT(XrPassthroughWindowApp)

--- a/Samples/XrSamples/XrPassthroughWindow/assets/assets.txt
+++ b/Samples/XrSamples/XrPassthroughWindow/assets/assets.txt
@@ -1,0 +1,1 @@
+This file is a placeholder.

--- a/Samples/XrSamples/XrPassthroughWindow/java/MainActivity.java
+++ b/Samples/XrSamples/XrPassthroughWindow/java/MainActivity.java
@@ -1,0 +1,3 @@
+package com.oculus.sdk.xrpassthroughwindow;
+
+public class MainActivity extends android.app.NativeActivity {}


### PR DESCRIPTION
## Summary
- add a new sample `XrPassthroughWindow` showing passthrough with a floating window
- enable resizing and fading the quad via controller joystick
- include minimal Android build files and helper code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534cf2ac948331afaf65b5fd13c334